### PR TITLE
CHEF-30488 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2020-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -29,5 +29,6 @@ Add these [dictionary definition](https://cspell.org/docs/dictionaries/#dictiona
 
 See the [chef/chef-web-docs cspell.json file](https://github.com/chef/chef-web-docs/blob/main/cspell.json) for an example of a fully configured CSpell config file.
 
-# Copyright
+## Copyright
+
 See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ Add these [dictionary definition](https://cspell.org/docs/dictionaries/#dictiona
 ```
 
 See the [chef/chef-web-docs cspell.json file](https://github.com/chef/chef-web-docs/blob/main/cspell.json) for an example of a fully configured CSpell config file.
+
+# Copyright
+See [COPYRIGHT.md](./COPYRIGHT.md).


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2020-2026 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
